### PR TITLE
make error enums public

### DIFF
--- a/Pod/Classes/LocationManager.swift
+++ b/Pod/Classes/LocationManager.swift
@@ -10,12 +10,12 @@
 import CoreLocation
 import PromiseKit
 
-enum LocationManagerError: ErrorType {
+public enum LocationManagerError: ErrorType {
     case LocationServiceDisabled
     case CannotFetchLocation
 }
 
-enum LocationManagerAuthorizationError: ErrorType {
+public enum LocationManagerAuthorizationError: ErrorType {
     case KeyInPlistMissing
 }
 


### PR DESCRIPTION
This allows checks like the following in project code

```
if let error = error as? LocationManagerError where error == .LocationServiceDisabled {
}
```
